### PR TITLE
Add product domain starter template

### DIFF
--- a/internal/app/product/interface/rest/product.go
+++ b/internal/app/product/interface/rest/product.go
@@ -1,0 +1,7 @@
+package rest
+
+type ProductHandler struct {}
+
+func NewProductHandler() {
+    ProductHandler := ProductHandler{}
+}

--- a/internal/app/product/repository/product.go
+++ b/internal/app/product/repository/product.go
@@ -1,0 +1,15 @@
+package repository
+
+import(
+    "gorm.io/gorm"
+)
+
+type ProductMySQLItf interface {}
+
+type ProductMySQL struct {
+    db *gorm.DB
+}
+
+func NewProductMySQL(db *gorm.DB) ProductMySQLItf {
+    return &ProductMySQL{db}
+}

--- a/internal/app/product/usecase/product.go
+++ b/internal/app/product/usecase/product.go
@@ -1,0 +1,9 @@
+package usecase
+
+type ProductUsecaseItf interface {}
+
+type ProductUsecase struct {}
+
+func NewProductUsecase() ProductUsecaseItf {
+    return &ProductUsecase{}
+}

--- a/internal/domain/dto/product.go
+++ b/internal/domain/dto/product.go
@@ -1,0 +1,1 @@
+package dto

--- a/internal/domain/entity/product.go
+++ b/internal/domain/entity/product.go
@@ -1,0 +1,5 @@
+package entity
+
+type Product struct {
+
+}


### PR DESCRIPTION
This pull request introduces the initial structure for the product module, including the handler, repository, usecase, and domain layers. The most important changes are the creation of interfaces and struct definitions for each layer.

Creation of product module structure:

* [`internal/app/product/interface/rest/product.go`](diffhunk://#diff-fe0012d014bfd17e40da8c19b567cf90e8f3f1f1064af503404e334d34576457R1-R7): Added `ProductHandler` struct and `NewProductHandler` function to initialize it.
* [`internal/app/product/repository/product.go`](diffhunk://#diff-3b6729cf47b10e741b552228fd859fffefa225049a8f73db2540d82e9c7d1b7dR1-R15): Added `ProductMySQLItf` interface, `ProductMySQL` struct, and `NewProductMySQL` function to initialize it with a `gorm.DB` instance.
* [`internal/app/product/usecase/product.go`](diffhunk://#diff-410af35a3eb19e60c9ee753c2eb6ee416c67688825099e1e0a2191fbddb822d5R1-R9): Added `ProductUsecaseItf` interface, `ProductUsecase` struct, and `NewProductUsecase` function to initialize it.

Domain layer setup:

* [`internal/domain/dto/product.go`](diffhunk://#diff-a82ca9cc828d3412b601f997be783262630182eda536561e860fe71ff97a1054R1): Created the `dto` package for data transfer objects.
* [`internal/domain/entity/product.go`](diffhunk://#diff-c5647ebddb037b87722c81ec9e1e870e50fdaf09b7c3321d94aed96227943c08R1-R5): Created the `entity` package and added the `Product` struct.