### PR TITLE
Add email in verification query url

### DIFF
--- a/internal/app/auth/interface/rest/auth.go
+++ b/internal/app/auth/interface/rest/auth.go
@@ -23,7 +23,7 @@ func NewAuthHandler(routerGroup fiber.Router, userUsecase usecase.AuthUsecaseItf
 	routerGroup = routerGroup.Group("/auth")
 	routerGroup.Post("/register", AuthHandler.Register)
 	routerGroup.Post("/login", AuthHandler.Login)
-	routerGroup.Post("/request-verification", limiter.Set(3, "15m"), AuthHandler.RequestVerification)
+	routerGroup.Post("/resend-verification", limiter.Set(3, "15m"), AuthHandler.RequestVerification)
 	routerGroup.Post("/verify", AuthHandler.VerifyUser)
 	routerGroup.Post("/forgot-password", limiter.Set(3, "15m"), AuthHandler.ForgotPassword)
 	routerGroup.Patch("/reset-password", AuthHandler.ResetPassword)

--- a/internal/app/auth/interface/rest/auth.go
+++ b/internal/app/auth/interface/rest/auth.go
@@ -49,7 +49,7 @@ func (h AuthHandler) Register(ctx *fiber.Ctx) error {
 		return res.Error(ctx, err)
 	}
 
-	return res.SuccessResponse(ctx, res.RegisterSuccess, user.AsResponse())
+	return res.SuccessResponse(ctx, res.RegisterSuccess, nil)
 }
 
 func (h AuthHandler) RequestVerification(ctx *fiber.Ctx) error {

--- a/internal/app/auth/interface/rest/auth.go
+++ b/internal/app/auth/interface/rest/auth.go
@@ -23,7 +23,7 @@ func NewAuthHandler(routerGroup fiber.Router, userUsecase usecase.AuthUsecaseItf
 	routerGroup = routerGroup.Group("/auth")
 	routerGroup.Post("/register", AuthHandler.Register)
 	routerGroup.Post("/login", AuthHandler.Login)
-	routerGroup.Post("/resend-verification", limiter.Set(3, "15m"), AuthHandler.RequestVerification)
+	routerGroup.Post("/resend-verification", limiter.Set(3, "15m"), AuthHandler.ResendVerification)
 	routerGroup.Post("/verify", AuthHandler.VerifyUser)
 	routerGroup.Post("/forgot-password", limiter.Set(3, "15m"), AuthHandler.ForgotPassword)
 	routerGroup.Patch("/reset-password", AuthHandler.ResetPassword)
@@ -45,15 +45,15 @@ func (h AuthHandler) Register(ctx *fiber.Ctx) error {
 		return res.Error(ctx, err)
 	}
 
-	if err := h.AuthUsecase.RequestVerification(dto.RequestTokenRequest{Email: user.Email}); err != nil {
+	if err := h.AuthUsecase.ResendVerification(dto.EmailVerificationRequest{Email: user.Email}); err != nil {
 		return res.Error(ctx, err)
 	}
 
 	return res.SuccessResponse(ctx, res.RegisterSuccess, nil)
 }
 
-func (h AuthHandler) RequestVerification(ctx *fiber.Ctx) error {
-	requestToken := new(dto.RequestTokenRequest)
+func (h AuthHandler) ResendVerification(ctx *fiber.Ctx) error {
+	requestToken := new(dto.EmailVerificationRequest)
 	if err := ctx.BodyParser(requestToken); err != nil {
 		return res.BadRequest(ctx)
 	}
@@ -62,7 +62,7 @@ func (h AuthHandler) RequestVerification(ctx *fiber.Ctx) error {
 		return res.ValidationError(ctx, nil, err)
 	}
 
-	if err := h.AuthUsecase.RequestVerification(*requestToken); err != nil {
+	if err := h.AuthUsecase.ResendVerification(*requestToken); err != nil {
 		return res.Error(ctx, err)
 	}
 

--- a/internal/app/auth/usecase/auth.go
+++ b/internal/app/auth/usecase/auth.go
@@ -18,7 +18,7 @@ import (
 type AuthUsecaseItf interface {
 	Register(dto.RegisterRequest) *res.Err
 	Login(login dto.LoginRequest) (string, *res.Err)
-	RequestVerification(requestToken dto.RequestTokenRequest) *res.Err
+	ResendVerification(requestToken dto.EmailVerificationRequest) *res.Err
 	VerifyUser(verifyUser dto.VerifyUserRequest) *res.Err
 	ForgotPassword(resetPassword dto.ForgotPasswordRequest) *res.Err
 	ResetPassword(data dto.ResetPasswordRequest) *res.Err
@@ -108,7 +108,7 @@ func (u *AuthUsecase) Login(data dto.LoginRequest) (string, *res.Err) {
 	return token, nil
 }
 
-func (u *AuthUsecase) RequestVerification(data dto.RequestTokenRequest) *res.Err {
+func (u *AuthUsecase) ResendVerification(data dto.EmailVerificationRequest) *res.Err {
 	user := new(entity.User)
 	err := u.UserRepository.Get(user, dto.UserParam{Email: data.Email})
 	if err != nil {

--- a/internal/app/partner/interface/rest/partner.go
+++ b/internal/app/partner/interface/rest/partner.go
@@ -32,7 +32,7 @@ func (h *PartnerHandler) RegisterPartner(ctx *fiber.Ctx) error {
 	}
 
 	if err := h.Validator.Struct(data); err != nil {
-		return res.ValidationError(ctx, data.AsResponse(), err)
+		return res.ValidationError(ctx, nil, err)
 	}
 
 	userId := ctx.Locals("userId").(uuid.UUID)
@@ -40,7 +40,5 @@ func (h *PartnerHandler) RegisterPartner(ctx *fiber.Ctx) error {
 		return res.Error(ctx, err)
 	}
 
-	return res.SuccessResponse(ctx, res.PartnerRegisterSuccess, fiber.Map{
-		"partner": data.AsResponse(),
-	})
+	return res.SuccessResponse(ctx, res.PartnerRegisterSuccess, nil)
 }

--- a/internal/app/partner/interface/rest/partner.go
+++ b/internal/app/partner/interface/rest/partner.go
@@ -22,7 +22,7 @@ func NewPartnerHandler(routerGroup fiber.Router, partnerUsecase usecase.PartnerU
 	}
 
 	routerGroup = routerGroup.Group("/partners")
-	routerGroup.Post("/register", m.Authentication, PartnerHandler.RegisterPartner)
+	routerGroup.Post("/register", m.Authentication, m.EnsureNotPartner, PartnerHandler.RegisterPartner)
 }
 
 func (h *PartnerHandler) RegisterPartner(ctx *fiber.Ctx) error {

--- a/internal/domain/dto/auth.go
+++ b/internal/domain/dto/auth.go
@@ -9,11 +9,6 @@ type RegisterRequest struct {
 	IsVerified bool   `json:"is_verified"`
 }
 
-type RegisterResponse struct {
-	Username string `json:"username"`
-	Email    string `json:"email"`
-}
-
 type RequestTokenRequest struct {
 	Email string `json:"email" validate:"required,email"`
 }
@@ -55,14 +50,4 @@ type UserParam struct {
 	Id       uuid.UUID
 	Email    string
 	Username string
-}
-
-type Empty struct {
-}
-
-func (r RegisterRequest) AsResponse() RegisterResponse {
-	return RegisterResponse{
-		Username: r.Username,
-		Email:    r.Email,
-	}
 }

--- a/internal/domain/dto/auth.go
+++ b/internal/domain/dto/auth.go
@@ -9,7 +9,7 @@ type RegisterRequest struct {
 	IsVerified bool   `json:"is_verified"`
 }
 
-type RequestTokenRequest struct {
+type EmailVerificationRequest struct {
 	Email string `json:"email" validate:"required,email"`
 }
 

--- a/internal/domain/dto/partner.go
+++ b/internal/domain/dto/partner.go
@@ -1,10 +1,10 @@
 package dto
 
 type RegisterPartnerRequest struct {
-	Name      string  `form:"name" json:"name" validate:"required"`
-	Type      string  `form:"type" json:"type" validate:"required"`
-	Address   string  `form:"address" json:"address" validate:"required"`
-	City      string  `form:"city" json:"city" validate:"required"`
-	Longitude float64 `form:"longitude" json:"longitude" validate:"required,longitude"`
-	Latitude  float64 `form:"latitude" json:"latitude" validate:"required,latitude"`
+	Name      string  `form:"name" validate:"required"`
+	Type      string  `form:"type" validate:"required"`
+	Address   string  `form:"address" validate:"required"`
+	City      string  `form:"city" validate:"required"`
+	Longitude float64 `form:"longitude" validate:"required,longitude"`
+	Latitude  float64 `form:"latitude" validate:"required,latitude"`
 }

--- a/internal/domain/dto/partner.go
+++ b/internal/domain/dto/partner.go
@@ -8,23 +8,3 @@ type RegisterPartnerRequest struct {
 	Longitude float64 `form:"longitude" json:"longitude" validate:"required,longitude"`
 	Latitude  float64 `form:"latitude" json:"latitude" validate:"required,latitude"`
 }
-
-type RegisterPartnerResponse struct {
-	Name      string  `json:"name"`
-	Type      string  `json:"type"`
-	Address   string  `json:"address"`
-	City      string  `json:"city"`
-	Longitude float64 `json:"longitude"`
-	Latitude  float64 `json:"latitude"`
-}
-
-func (r *RegisterPartnerRequest) AsResponse() RegisterPartnerResponse {
-	return RegisterPartnerResponse{
-		Name:      r.Name,
-		Type:      r.Type,
-		Address:   r.Address,
-		City:      r.City,
-		Longitude: r.Longitude,
-		Latitude:  r.Latitude,
-	}
-}

--- a/internal/infra/email/email.go
+++ b/internal/infra/email/email.go
@@ -56,7 +56,7 @@ func (e *Email) SendEmailVerification(to string, token string) error {
 	message.SetHeader("To", to)
 	message.SetHeader("Subject", "Email Verification")
 
-	message.SetBody("text/html", fmt.Sprintf(body, e.appURL, token))
+	message.SetBody("text/html", fmt.Sprintf(body, e.appURL, to, token))
 
 	return e.sendEmail(e.connect(), message)
 }

--- a/internal/infra/email/template/verification.html
+++ b/internal/infra/email/template/verification.html
@@ -2,6 +2,6 @@
     <body>
         <h1>This is an Email from Ambic</h1>
         Click this link to verify your account:
-        <a href="%s/verify?token=%s">Verify account</a>
+        <a href="%s/verify?email=%s&token=%s">Verify account</a>
     </body>
 </html>

--- a/internal/middleware/ensure_not_partner.go
+++ b/internal/middleware/ensure_not_partner.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	res "ambic/internal/infra/response"
+	"github.com/gofiber/fiber/v2"
+)
+
+func (m *Middleware) EnsureNotPartner(ctx *fiber.Ctx) error {
+	isPartner := ctx.Locals("isPartner").(bool)
+	if isPartner {
+		return res.Unauthorized(ctx)
+	}
+
+	return ctx.Next()
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -8,6 +8,7 @@ import (
 type MiddlewareIf interface {
 	Authentication(ctx *fiber.Ctx) error
 	EnsurePartner(ctx *fiber.Ctx) error
+	EnsureNotPartner(ctx *fiber.Ctx) error
 }
 
 type Middleware struct {


### PR DESCRIPTION
This pull request includes several changes to the authentication and partner registration functionalities, focusing on renaming methods and improving the verification process. Additionally, it introduces a new middleware to ensure users are not partners during registration.

### Authentication Changes:
* Renamed `RequestVerification` to `ResendVerification` in multiple files and updated the associated request type from `RequestTokenRequest` to `EmailVerificationRequest`. [[1]](diffhunk://#diff-31136432cc08c7292ec44ad2fca4ae7fea2093c484f167b89d9a872c5c411816L26-R26) [[2]](diffhunk://#diff-31136432cc08c7292ec44ad2fca4ae7fea2093c484f167b89d9a872c5c411816L48-R56) [[3]](diffhunk://#diff-31136432cc08c7292ec44ad2fca4ae7fea2093c484f167b89d9a872c5c411816L65-R65) [[4]](diffhunk://#diff-8a401d96311a71aa0c341e814d89d5309e64902cf97e2bca698f070f0f8d7d09L21-R21) [[5]](diffhunk://#diff-8a401d96311a71aa0c341e814d89d5309e64902cf97e2bca698f070f0f8d7d09L111-R111)
* Modified the `Register` method to return a success response without user details.
* Updated email verification template to include the email address in the verification link. [[1]](diffhunk://#diff-6807d7e241916ee6a1108848cc541f3159c1ddc69450c7d4090154d4a29f0e47L59-R59) [[2]](diffhunk://#diff-9948adee1ef2ab6e478b8675895c9e993562e2f96a162dc5d3e12b800586d558L5-R5)

### Partner Registration Changes:
* Added `EnsureNotPartner` middleware to prevent partners from registering again. [[1]](diffhunk://#diff-29bf17d049eb92d1b3413cfa984fe70916c6f7c414c6ce1d21971acaf41e560bL25-R25) [[2]](diffhunk://#diff-f7eb7432643c9aff7814dfc977554bc3553e64f91b2372b681a79f4c98434311R1-R15) [[3]](diffhunk://#diff-3413224df30ede06962678504193d621a87171fd26eed154919225315109efd7R11)
* Modified the `RegisterPartner` method to return a success response without partner details.

### DTO Changes:
* Replaced `RequestTokenRequest` with `EmailVerificationRequest` and removed unused response structs. [[1]](diffhunk://#diff-755da06e16168d9e67e291fbe45dacc0fc6ac7fb36aa928fa74e809238f5cb4dL12-R12) [[2]](diffhunk://#diff-755da06e16168d9e67e291fbe45dacc0fc6ac7fb36aa928fa74e809238f5cb4dL59-L68)
* Simplified `RegisterPartnerRequest` by removing the `AsResponse` method and the corresponding response struct.