### PR TITLE
Restructure routes

### DIFF
--- a/internal/app/partner/interface/rest/partner.go
+++ b/internal/app/partner/interface/rest/partner.go
@@ -28,13 +28,13 @@ func NewPartnerHandler(routerGroup fiber.Router, partnerUsecase usecase.PartnerU
 	}
 
 	routerGroup.Get("/partners/verification", limiter.Set(3, "15m"), PartnerHandler.RequestPartnerVerification)
+	routerGroup.Post("/partners/verification", PartnerHandler.VerifyPartner)
 
 	routerGroup = routerGroup.Group("/partners", m.Authentication)
 	routerGroup.Get("/", m.EnsurePartner, PartnerHandler.ShowLoggedInPartner)
 	routerGroup.Post("/", m.EnsureNotPartner, PartnerHandler.RegisterPartner)
 	routerGroup.Patch("/", m.EnsurePartner, m.EnsureVerifiedPartner, PartnerHandler.UpdatePhoto)
 	routerGroup.Get("/statistics", m.EnsurePartner, PartnerHandler.GetLoggedInPartnerStatistics)
-	routerGroup.Post("/verification", PartnerHandler.VerifyPartner)
 	routerGroup.Get("/products", m.EnsurePartner, m.EnsureVerifiedPartner, PartnerHandler.GetLoggedInPartnerProducts)
 	routerGroup.Get("/transactions", m.EnsurePartner, m.EnsureVerifiedPartner, PartnerHandler.GetLoggedInPartnerTransactions)
 	routerGroup.Get("/:id/products", m.EnsurePartner, m.EnsureVerifiedPartner, PartnerHandler.GetProducts)


### PR DESCRIPTION
This pull request includes a change to the `internal/app/partner/interface/rest/partner.go` file to improve the routing for partner verification. The most important changes include modifying the routes for partner verification to ensure proper endpoint usage.

Routing improvements:

* Added a new POST route for partner verification at `/partners/verification` to handle the verification process.
* Removed the old POST route for partner verification from the `/partners` group to avoid redundancy and potential conflicts.