### PR TITLE
Update GetRatingResponse to include user details and modify User

### DIFF
--- a/internal/app/rating/repository/rating.go
+++ b/internal/app/rating/repository/rating.go
@@ -25,7 +25,7 @@ func NewRatingMySQL(db *gorm.DB) RatingMySQLItf {
 }
 
 func (r *RatingMySQL) Get(rating *[]entity.Rating, param dto.RatingParam, pagination dto.PaginationRequest) (int64, error) {
-	result := r.db.Debug().Limit(pagination.Limit).Offset(pagination.Offset).Order("created_at desc").Find(rating, param)
+	result := r.db.Debug().Preload("User").Limit(pagination.Limit).Offset(pagination.Offset).Order("created_at desc").Find(rating, param)
 
 	var count int64
 	result.Count(&count)

--- a/internal/domain/dto/rating.go
+++ b/internal/domain/dto/rating.go
@@ -17,13 +17,13 @@ type ShowRatingRequest struct {
 }
 
 type GetRatingResponse struct {
-	ID        string    `json:"id"`
-	ProductID string    `json:"product_id"`
-	UserID    string    `json:"user_id"`
-	Star      int       `json:"star"`
-	Feedback  string    `json:"feedback"`
-	Photo     string    `json:"photo"`
-	Datetime  time.Time `json:"datetime"`
+	ID        string          `json:"id"`
+	ProductID string          `json:"product_id"`
+	User      GetUserResponse `json:"user"`
+	Star      int             `json:"star"`
+	Feedback  string          `json:"feedback"`
+	Photo     string          `json:"photo"`
+	Datetime  time.Time       `json:"datetime"`
 }
 
 type CreateRatingRequest struct {

--- a/internal/domain/entity/rating.go
+++ b/internal/domain/entity/rating.go
@@ -11,6 +11,7 @@ type Rating struct {
 	ID        uuid.UUID `gorm:"type:char(36);primaryKey"`
 	ProductID uuid.UUID `gorm:"type:char(36);uniqueIndex:idx_product_user"`
 	UserID    uuid.UUID `gorm:"type:char(36);uniqueIndex:idx_product_user"`
+	User      User
 	Star      int       `gorm:"type:int(8);not null"`
 	Feedback  string    `gorm:"type:varchar(1000)"`
 	PhotoURL  string    `gorm:"type:varchar(255);default:null"`
@@ -28,7 +29,7 @@ func (r *Rating) ParseDTOGet() dto.GetRatingResponse {
 	return dto.GetRatingResponse{
 		ID:        r.ID.String(),
 		ProductID: r.ProductID.String(),
-		UserID:    r.UserID.String(),
+		User:      r.User.ParseDTOGet(),
 		Star:      r.Star,
 		Feedback:  r.Feedback,
 		Photo:     r.PhotoURL,


### PR DESCRIPTION
This pull request includes several changes to enhance the rating system by incorporating user details directly into the rating responses. The most important changes include modifying the `GetRatingResponse` struct to include a `User` field, updating the `Rating` entity to include a `User` association, and adjusting the `ParseDTOGet` method to reflect these changes.

Enhancements to rating system:

* [`internal/domain/dto/rating.go`](diffhunk://#diff-d0c4552118cd731e8bd7eaaa99b1ec5924e40102204562ae9c13cffc9ac700c5L22-R22): Changed the `GetRatingResponse` struct to replace the `UserID` field with a `User` field that holds `GetUserResponse`.
* [`internal/domain/entity/rating.go`](diffhunk://#diff-e7128ffcf8e130ab9caf7b215a1dbbe10f6d565b2103e78c30596fb48089e54dR14): Updated the `Rating` struct to include a `User` field for holding user details.
* [`internal/domain/entity/rating.go`](diffhunk://#diff-e7128ffcf8e130ab9caf7b215a1dbbe10f6d565b2103e78c30596fb48089e54dL31-R32): Modified the `ParseDTOGet` method in the `Rating` entity to map the `User` field to the `GetRatingResponse`.