### PR TITLE
Use specific port when listening app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+APP_HOST=127.0.0.1
 APP_PORT=8080
 APP_URL=http://127.0.0.1:8080
 APP_LOGO_PATH=assets/logo.png

--- a/internal/bootstrap/bootstrap.go
+++ b/internal/bootstrap/bootstrap.go
@@ -137,5 +137,5 @@ func Start() error {
 	locationUsecase := LocationUsecase.NewLocationUsecase(ma)
 	LocationHandler.NewLocationHandler(v1, locationUsecase, m, v)
 
-	return app.Listen(fmt.Sprintf(":%d", config.AppPort))
+	return app.Listen(fmt.Sprintf("%s:%d", config.AppHost, config.AppPort))
 }

--- a/internal/domain/env/env.go
+++ b/internal/domain/env/env.go
@@ -8,6 +8,7 @@ import (
 )
 
 type Env struct {
+	AppPort                string `env:"APP_HOST"`
 	AppPort                int    `env:"APP_PORT"`
 	AppURL                 string `env:"APP_URL"`
 	AppLogoPath            string `env:"APP_LOGO_PATH"`


### PR DESCRIPTION
This pull request includes changes to support configuring the application host through the environment variables. The most important changes include adding a new environment variable `APP_HOST`, updating the application to use this new variable, and modifying the environment configuration structure.

### Environment Configuration Updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1): Added `APP_HOST` variable to specify the application host.
* [`internal/domain/env/env.go`](diffhunk://#diff-c7e3a73589d7bc3784c1044cc9f451d89b1473b733806e9d6d68d900825a5c77R11): Added `AppHost` field to the `Env` struct to read the `APP_HOST` environment variable.

### Application Code Updates:

* [`internal/bootstrap/bootstrap.go`](diffhunk://#diff-2ff3a3bcfc0c1695c074d2a42de2b237a7e6f0e1b01ed090a57207cd4725226cL140-R140): Modified the `Start` function to use the `APP_HOST` variable in the `app.Listen` method.