### PR TITLE
Update Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,22 @@
-version: '3.9'
-
 services:
   app:
     build: .
+    restart: unless-stopped
     ports:
-      - "127.0.0.1:${APP_PORT}:8080"
+      - "${APP_PORT}:3000"
     env_file:
       - .env
     depends_on:
       - db
       - redis
+    networks:
+      - ambic
 
   db:
     image: mysql:8.0
-    restart: always
+    restart: unless-stopped
     ports:
-      - "127.0.0.1:3307:3306"
+      - "3307:3306"
     env_file:
       - .env
     environment:
@@ -23,15 +24,22 @@ services:
       MYSQL_DATABASE: ${DB_NAME}
     volumes:
       - db_data:/var/lib/mysql
+    networks:
+      - ambic
 
   redis:
     image: redis:7
-    restart: always
+    restart: unless-stopped
     ports:
-      - "127.0.0.1:6379:6379"
+      - "6379:6379"
     env_file:
       - .env
+    networks:
+      - ambic
 
 volumes:
   db_data:
 
+networks:
+  ambic:
+    driver: bridge


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to improve container management and networking configuration. The most significant changes include modifying the restart policy, adjusting port mappings, and introducing a custom network named `ambic`.

### Container Management Improvements:
* Changed the restart policy for services (`app`, `db`, and `redis`) from `always` to `unless-stopped` to provide better control over container behavior during failures or manual stops.

### Networking Enhancements:
* Added a custom network named `ambic` with `bridge` driver and connected all services (`app`, `db`, and `redis`) to this network for improved isolation and communication.

### Port Configuration Adjustments:
* Updated port mappings to remove `127.0.0.1` bindings for all services, allowing broader accessibility:
  - [`app`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R45): Changed from `127.0.0.1:${APP_PORT}:8080` to `${APP_PORT}:3000`.
  - [`db`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R45): Changed from `127.0.0.1:3307:3306` to `3307:3306`.
  - [`redis`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R45): Changed from `127.0.0.1:6379:6379` to `6379:6379`.