### PR TITLE
chore: change version of mysql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ambic
 
   db:
-    image: mysql:8.0
+    image: mysql:8.0.28
     restart: unless-stopped
     ports:
       - "3307:3306"


### PR DESCRIPTION
This pull request includes a minor update to the `docker-compose.yml` file. The change updates the MySQL image version used for the `db` service.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L16-R16): Updated the MySQL image from `mysql:8.0` to `mysql:8.0.28` for the `db` service to ensure compatibility or include the latest fixes.